### PR TITLE
Allow backend to compile with CMake on OS X

### DIFF
--- a/backend/cxx/CMakeLists.txt
+++ b/backend/cxx/CMakeLists.txt
@@ -55,7 +55,9 @@ ADD_LIBRARY(trace SHARED
     src/infer/meanfield.cxx
     src/utils.cxx
     src/check.cxx
+    src/omegadb.cxx
     src/sp.cxx
+    src/spaux.cxx
     src/scaffold.cxx
     src/sps/csp.cxx
     src/sps/mem.cxx
@@ -67,6 +69,7 @@ ADD_LIBRARY(trace SHARED
     src/sps/continuous.cxx
     src/sps/discrete.cxx
     src/sps/cond.cxx
+    src/sps/sym.cxx
     src/sps/vector.cxx
     src/sps/list.cxx
     src/sps/map.cxx

--- a/backend/cxx/src/check.cxx
+++ b/backend/cxx/src/check.cxx
@@ -15,6 +15,7 @@
 * 
 * You should have received a copy of the GNU General Public License along with Venture.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "Python.h"
 #include "check.h"
 #include "node.h"
 #include "trace.h"

--- a/backend/cxx/src/infer/gibbs.cxx
+++ b/backend/cxx/src/infer/gibbs.cxx
@@ -15,6 +15,7 @@
 * 
 * You should have received a copy of the GNU General Public License along with Venture.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "Python.h"
 #include "infer/mh.h"
 #include "infer/gibbs.h"
 #include "flush.h"

--- a/backend/cxx/src/infer/meanfield.cxx
+++ b/backend/cxx/src/infer/meanfield.cxx
@@ -15,6 +15,7 @@
 * 
 * You should have received a copy of the GNU General Public License along with Venture.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "Python.h"
 #include "lkernel.h"
 #include "infer/meanfield.h"
 #include "trace.h"

--- a/backend/cxx/src/infer/pgibbs.cxx
+++ b/backend/cxx/src/infer/pgibbs.cxx
@@ -15,6 +15,7 @@
 * 
 * You should have received a copy of the GNU General Public License along with Venture.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "Python.h"
 #include "infer/mh.h"
 #include "infer/pgibbs.h"
 #include "flush.h"

--- a/backend/cxx/src/rcs.cxx
+++ b/backend/cxx/src/rcs.cxx
@@ -15,6 +15,7 @@
 * 
 * You should have received a copy of the GNU General Public License along with Venture.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "Python.h"
 #include "trace.h"
 #include <iostream>
 


### PR DESCRIPTION
1. Added 'include "Python.h"' to top of several sources.
   This fixes errors of form
   
    error: macro "XYZ" passed 2 arguments, but takes just 1
2. Added some missing dependencies for "trace" target
   to CMakeLists.txt
