### PR TITLE
Add comment-line-only support to both the venture_script and church_prime parsers

### DIFF
--- a/python/lib/parser/church_prime/parse.py
+++ b/python/lib/parser/church_prime/parse.py
@@ -307,7 +307,9 @@ def parse_instructions(string):
 
 def parse_instruction(string):
     ls = parse_instructions(string)
-    if len(ls) != 1:
+    if not ls:
+        return None
+    if len(ls) > 1:
         raise VentureException('parse', 'Expected a single instruction')
     return ls[0]
 
@@ -488,7 +490,8 @@ class ChurchPrimeParser(object):
     def parse_instruction(self, string):
         '''Parse STRING as a single instruction.'''
         l = parse_instruction(string)
-        return dict((k, delocust(v)) for k, v in l['value'].iteritems())
+        if l:
+            return dict((k, delocust(v)) for k, v in l['value'].iteritems())
 
     def parse_locexpression(self, string):
         '''Parse STRING as an expression, and include location records.'''
@@ -622,14 +625,15 @@ class ChurchPrimeParser(object):
         [1] a dict mapping operand keys to [start, end] positions.
         '''
         l = parse_instruction(string)
-        locs = dict((k, v['loc']) for k, v in l['value'].iteritems())
-        # XXX + 1?
-        strings = dict((k, string[loc[0] : loc[1] + 1]) for k, loc in
-            locs.iteritems())
-        # XXX Sort???
-        sortlocs = dict((k, list(sorted(loc))) for k, loc in locs.iteritems())
-        # XXX List???
-        return [strings, sortlocs]
+        if l:
+            locs = dict((k, v['loc']) for k, v in l['value'].iteritems())
+            # XXX + 1?
+            strings = dict((k, string[loc[0] : loc[1] + 1]) for k, loc in
+                locs.iteritems())
+            # XXX Sort???
+            sortlocs = dict((k, list(sorted(loc))) for k, loc in locs.iteritems())
+            # XXX List???
+            return [strings, sortlocs]
 
     # XXX Make the tests pass, nobody else calls this.
     def character_index_to_expression_index(self, _string, index):

--- a/python/lib/parser/venture_script/parse.py
+++ b/python/lib/parser/venture_script/parse.py
@@ -475,15 +475,18 @@ def parse_instructions(string):
 
 def parse_instruction(string):
     ls = parse_instructions(string)
-    if len(ls) != 1:
+    if not ls:
+        return None
+    if len(ls) > 1:
         raise VentureException('text_parse', 'Expected a single instruction')
     return ls[0]
 
 def parse_expression(string):
     inst = parse_instruction(string)['value']
-    if not inst['instruction']['value'] == 'evaluate':
-        raise VentureException('text_parse', 'Expected an expression')
-    return inst['expression']
+    if inst:
+        if not inst['instruction']['value'] == 'evaluate':
+            raise VentureException('text_parse', 'Expected an expression')
+        return inst['expression']
 
 def value_to_string(v):
     if isinstance(v, dict):
@@ -656,7 +659,8 @@ class VentureScriptParser(object):
     def parse_instruction(self, string):
         '''Parse STRING as a single instruction.'''
         l = parse_instruction(string)
-        return dict((k, delocust(v)) for k, v in l['value'].iteritems())
+        if l:
+            return dict((k, delocust(v)) for k, v in l['value'].iteritems())
 
     def parse_locexpression(self, string):
         '''Parse STRING as an expression, and include location records.'''

--- a/python/lib/ripl/ripl.py
+++ b/python/lib/ripl/ripl.py
@@ -132,12 +132,16 @@ class Ripl():
                 stringable_instruction = instruction
                 parsed_instruction = self._ensure_parsed(instruction)
             # if directive, then save the text string
-            if parsed_instruction['instruction'] in ['assume', 'observe', 'predict', 'define',
-                                                     'labeled_assume','labeled_observe','labeled_predict']:
-                did = self.sivm.core_sivm.engine.predictNextDirectiveId()
-                self.directive_id_to_stringable_instruction[did] = stringable_instruction
-                self.directive_id_to_mode[did] = self.mode
-            ret_value = self.sivm.execute_instruction(parsed_instruction)
+            ret_value = None
+            if parsed_instruction:
+                if parsed_instruction['instruction'] in [
+                        'assume', 'observe', 'predict', 'define',
+                        'labeled_assume','labeled_observe','labeled_predict']:
+                    did = self.sivm.core_sivm.engine.predictNextDirectiveId()
+                    self.directive_id_to_stringable_instruction[did] = (
+                        stringable_instruction)
+                    self.directive_id_to_mode[did] = self.mode
+                ret_value = self.sivm.execute_instruction(parsed_instruction)
         except VentureException as e:
             if self._do_not_annotate:
                 raise


### PR DESCRIPTION
Also adds some tests for multiline support in the abstract syntax.
