### PR TITLE
explicit sentinel for NO_PARSE_EXPRESSION

### DIFF
--- a/python/lib/parser/venture_script/parse.py
+++ b/python/lib/parser/venture_script/parse.py
@@ -65,6 +65,8 @@ def locbracket((_ovalue, ostart, oend), (_cvalue, cstart, cend), value):
     assert cstart <= cend
     return located([ostart, cend], value)
 
+NO_PARSE_EXPRESSION = val.NO_PARSE_EXPRESSION
+
 def delocust(l):
     # XXX Why do we bother with tuples in the first place?
     if isinstance(l['value'], list) or isinstance(l['value'], tuple):
@@ -428,6 +430,8 @@ def parse(f, context):
     assert isinstance(semantics.answer, list)
     for i in semantics.answer:
         assert isloc(i)
+    if semantics.answer is None:
+        return NO_PARSE_EXPRESSION
     return semantics.answer
 
 def parse_string(string):
@@ -470,6 +474,7 @@ def string_complete_p(string):
                     return False
             else:
                 parser.feed(token)
+    return NO_PARSE_EXPRESSION
 
 def parse_instructions(string):
     return parse_string(string)
@@ -477,17 +482,18 @@ def parse_instructions(string):
 def parse_instruction(string):
     ls = parse_instructions(string)
     if not ls:
-        return None
+        return NO_PARSE_EXPRESSION
     if len(ls) > 1:
         raise VentureException('text_parse', 'Expected a single instruction')
     return ls[0]
 
 def parse_expression(string):
     inst = parse_instruction(string)['value']
-    if inst:
-        if not inst['instruction']['value'] == 'evaluate':
-            raise VentureException('text_parse', 'Expected an expression')
-        return inst['expression']
+    if inst == NO_PARSE_EXPRESSION:
+        return inst
+    if not inst['instruction']['value'] == 'evaluate':
+        raise VentureException('text_parse', 'Expected an expression')
+    return inst['expression']
 
 def value_to_string(v):
     if isinstance(v, dict):
@@ -652,8 +658,10 @@ class VentureScriptParser(object):
     def parse_instruction(self, string):
         '''Parse STRING as a single instruction.'''
         l = parse_instruction(string)
-        if l:
-            return dict((k, delocust(v)) for k, v in l['value'].iteritems())
+        if l is NO_PARSE_EXPRESSION:
+            return NO_PARSE_EXPRESSION
+        return dict((k, delocust(v)) for k, v in l['value'].iteritems())
+
 
     def parse_locexpression(self, string):
         '''Parse STRING as an expression, and include location records.'''
@@ -770,6 +778,8 @@ class VentureScriptParser(object):
         [1] a list of [start, end] positions of each instruction in STRING.
         '''
         ls = parse_instructions(string)
+        if ls == NO_PARSE_EXPRESSION:
+            return [[], []]
         locs = [l['loc'] for l in ls]
         # XXX + 1?
         strings = [string[loc[0] : loc[1] + 1] for loc in locs]
@@ -787,6 +797,8 @@ class VentureScriptParser(object):
         [1] a dict mapping operand keys to [start, end] positions.
         '''
         l = parse_instruction(string)
+        if l == NO_PARSE_EXPRESSION:
+            return [[], []]
         locs = dict((k, v['loc']) for k, v in l['value'].iteritems())
         # XXX + 1?
         strings = dict((k, string[loc[0] : loc[1] + 1]) for k, loc in

--- a/python/lib/ripl/ripl.py
+++ b/python/lib/ripl/ripl.py
@@ -132,8 +132,8 @@ class Ripl():
                 stringable_instruction = instruction
                 parsed_instruction = self._ensure_parsed(instruction)
             # if directive, then save the text string
-            ret_value = None
-            if parsed_instruction:
+            ret_value = None  # None is appropriate, not just a sentinel.
+            if parsed_instruction != v.NO_PARSE_EXPRESSION:
                 if parsed_instruction['instruction'] in [
                         'assume', 'observe', 'predict', 'define',
                         'labeled_assume','labeled_observe','labeled_predict']:

--- a/python/lib/value/dicts.py
+++ b/python/lib/value/dicts.py
@@ -23,6 +23,8 @@ import numbers
 python_list = list
 python_dict = dict
 
+NO_PARSE_EXPRESSION = {None: "__NO_PARSE_EXPRESSION__"}
+
 def val(t,v):
   return {"type":t,"value":v}
 

--- a/test/stack/functionality/churchprime_parser_test.py
+++ b/test/stack/functionality/churchprime_parser_test.py
@@ -33,7 +33,8 @@ class TestChurchPrimeParser(unittest.TestCase):
         self.expression = None
 
     def test_expression(self):
-        self.assertEqual(None, self.p.parse_locexpression(""))
+        self.assertEqual(v.NO_PARSE_EXPRESSION,
+                         self.p.parse_locexpression(""))
         self.assertEqual(self.p.parse_locexpression("(a b (c real<1>))"),
                 {'loc': [0,16], 'value':[
                     {'loc': [1,1], 'value': v.sym('a')},


### PR DESCRIPTION
Riastradh commented re
https://github.com/mit-probabilistic-computing-project/Venturecxx/pull/148/files
and
https://github.com/mit-probabilistic-computing-project/Venturecxx/pull/108/files
that returning None by design has the potential to mask accidental returns of None, so I've used a new named sentinel value instead.
