### PR TITLE
trace functionality: "seal" the environment after the inference prelude

### DIFF
--- a/backend/lite/trace.py
+++ b/backend/lite/trace.py
@@ -54,7 +54,7 @@ class Trace(object):
       self.bindPrimitiveName(name, val)
     for name,sp in builtInSPs().iteritems():
       self.bindPrimitiveSP(name, sp)
-    self.globalEnv = VentureEnvironment(self.globalEnv) # New frame so users can shadow globals
+    self.sealEnvironment() # New frame so users can shadow globals
 
     self.rcs = set()
     self.ccs = set()
@@ -70,6 +70,9 @@ class Trace(object):
     # A hack for allowing scope names not to be quoted in inference
     # programs (needs to be a method so Puma can implement it)
     return self.scopes.keys()
+
+  def sealEnvironment(self):
+    self.globalEnv = VentureEnvironment(self.globalEnv)
 
   def bindPrimitiveName(self, name, val):
     self.globalEnv.addBinding(name,self.createConstantNode(None, val))

--- a/backend/new_cxx/inc/concrete_trace.h
+++ b/backend/new_cxx/inc/concrete_trace.h
@@ -34,6 +34,7 @@ struct ConcreteTrace : Trace
   ConcreteTrace();
   void initialize();
   Node* bindPrimitiveSP(const string& name, SP* sp);
+  void sealEnvironment();
 
   /* Registering metadata */
   void registerAEKernel(Node * node);

--- a/backend/new_cxx/src/concrete_trace.cxx
+++ b/backend/new_cxx/src/concrete_trace.cxx
@@ -68,6 +68,11 @@ void ConcreteTrace::initialize()
   }
 
   // New frame so users can shadow globals
+  sealEnvironment();
+}
+
+void ConcreteTrace::sealEnvironment()
+{
   globalEnvironment = boost::shared_ptr<VentureEnvironment>(new VentureEnvironment(globalEnvironment));
 }
 

--- a/backend/untraced/trace.py
+++ b/backend/untraced/trace.py
@@ -36,7 +36,10 @@ class Trace(object):
       self.bindPrimitiveName(name, val)
     for name, sp in builtin.builtInSPs().iteritems():
       self.bindPrimitiveSP(name, sp)
-    self.env = env.VentureEnvironment(self.env) # New frame so users can shadow globals
+    self.sealEnvironment() # New frame so users can shadow globals
+
+  def sealEnvironment(self):
+    self.env = env.VentureEnvironment(self.env)
 
   def extractRaw(self, id):
     return self.results[id]

--- a/python/lib/engine/engine.py
+++ b/python/lib/engine/engine.py
@@ -262,6 +262,7 @@ class Engine(object):
   def install_inference_prelude(self, next_trace):
     for name, exp in _inference_prelude():
       self._define_in(name, exp, next_trace)
+    next_trace.sealEnvironment()
 
   def primitive_infer(self, exp): self.model.primitive_infer(exp)
   def logscore(self): return self.model.logscore()

--- a/test/regressions/test_variable_shadowing.py
+++ b/test/regressions/test_variable_shadowing.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2015 MIT Probabilistic Computing Project.
+#
+# This file is part of Venture.
+#
+# Venture is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Venture is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Venture.  If not, see <http://www.gnu.org/licenses/>.
+
+from nose.tools import eq_
+
+from venture.test.config import get_ripl, broken_in
+
+def testVariableShadowing():
+  """Prior to the patch in which we implemented Trace.sealEnvironment(), we were
+  able to destructively redefine symbols from the inference prelude, and things
+  exploded.  Now we should see a shadowing behavior when we try similar
+  definitions.
+"""
+  ripl = get_ripl()
+  ripl.execute_program('''
+[define repeat 3]
+''')
+  eq_(ripl.evaluate('repeat'), ripl.evaluate('3.0'))


### PR DESCRIPTION
Add a method to all Trace implementations that "seals" the environment by
replacing the current global environment with a child environment.  Apply this
method to seal the environment after the inference prelude is loaded, ensuring
that users can shadow prelude-level bindings but never redefine them.

Testing Done: test/regressions/test_variable_shadowing.py
Bug Number: 167 (https://github.com/probcomp/Venturecxx/issues/167)

Signed-off-by: Eli Sennesh eligottlieb@gmail.com
