### PR TITLE
Fix Gibbs wrong stationary distribution in the presence of brush.

### DIFF
--- a/backend/lite/infer/egibbs.py
+++ b/backend/lite/infer/egibbs.py
@@ -41,17 +41,31 @@ class EnumerativeGibbsOperator(object):
 
     registerDeterministicLKernels(trace,scaffold,pnodes,currentValues)
 
-    detachAndExtract(trace,scaffold)
+    rhoWeight, rhoDB = detachAndExtract(trace,scaffold)
     xiWeights = []
     xiParticles = []
 
     for p in range(len(allSetsOfValues)):
       newValues = allSetsOfValues[p]
+      if newValues == currentValues:
+        # If there are random choices downstream, keep their current values.
+        # This follows the auxiliary variable method in Neal 2000,
+        # "Markov Chain Sampling Methods for Dirichlet Process Models"
+        # (Algorithm 8 with m = 1).
+        # Otherwise, we may target the wrong stationary distribution.
+        # See test/inference_language/test_enumerative_gibbs.py for an example.
+        shouldRestore = True
+        omegaDB = rhoDB
+      else:
+        shouldRestore = False
+        omegaDB = OmegaDB()
       xiParticle = self.copy_trace(trace)
       assertTorus(scaffold)
       registerDeterministicLKernels(trace,scaffold,pnodes,newValues)
       xiParticles.append(xiParticle)
-      xiWeights.append(regenAndAttach(xiParticle,scaffold,False,OmegaDB(),{}))
+      xiWeights.append(regenAndAttach(xiParticle,scaffold,shouldRestore,omegaDB,{}))
+      # if shouldRestore:
+      #   assert_almost_equal(xiWeights[-1], rhoWeight)
     return (xiParticles, xiWeights)
 
   def propose(self, trace, scaffold):


### PR DESCRIPTION
This fixes issue #207 by conforming to Neal's Algorithm 8, which is
justified as an auxiliary variable Gibbs step. The main difference is
that if there are random choices y downstream of the variables being
enumerated, z, we retain the current values of y rather than
resampling new ones for the particle corresponding to the current z.
(The intuition is that randomly sampled values of y will tend to have
lower likelihood than the existing values, so the existing values may
otherwise be discarded more often than they should.)

A possible consequence is that the egibbs operator will consider fewer
different values of the downstream choices than before, but those
downstream choices can be subject to further inference anyway.
