### PR TITLE
Use "Fixed_param" option in minimal_stan_run.

### DIFF
--- a/python/lib/plugins/venstan.py
+++ b/python/lib/plugins/venstan.py
@@ -169,16 +169,9 @@ def cached_stan_model(model_code, cache_dir=None, **kwargs):
 def minimal_stan_run(model, **kwargs):
   """Create a StanFit object from a StanModel object.
 
-Avoid moving the parameters from their initialization as much as possible."""
-  # Apparently, pystan offers no way to completely avoid moving the
-  # parameters:
-  # https://github.com/stan-dev/pystan/issues/199
-  # https://github.com/stan-dev/pystan/issues/200
-  # For now, move a "small" amount (assuming the problem's geometry
-  # has unit scale).
-  control = {'adapt_engaged': False, 'stepsize': 1e-12, 'int_time': 1e-12,
-             'stepsize_jitter': 0}
-  ans = model.sampling(iter=1, chains=1, algorithm="HMC", control=control,
+Avoid moving the parameters from their initialization."""
+  ans = model.sampling(iter=1, chains=1, algorithm="Fixed_param",
+                       control={'adapt_engaged': False},
                        **kwargs)
   return ans
 


### PR DESCRIPTION
Fixes #253. It turns out that specifying {'adapt_engaged': False}
prevents the segfault:
https://github.com/stan-dev/pystan/issues/200#issuecomment-201075727
