### PR TITLE
Multiline paste for abstract syntax

### DIFF
--- a/python/lib/parser/church_prime/parse.py
+++ b/python/lib/parser/church_prime/parse.py
@@ -286,6 +286,27 @@ def parse_church_prime_string(string):
             e.data['text_index'] = [start - lstart, end - lstart]
         raise e
 
+
+def string_complete_p(string):
+    scanner = scan.Scanner(StringIO.StringIO(string), '(string)')
+    semantics = Semantics()
+    parser = grammar.Parser(semantics)
+    while True:
+        token = scanner.read()
+        if token[0] == -1:      # scan error
+            return True
+        else:
+            if token[0] == 0:   # EOF
+                try:
+                    parser.feed(token)
+                    # If the EOF parses, then we had a complete string
+                    return True
+                except VentureException:
+                    # Parse was not complete
+                    return False
+            else:
+                parser.feed(token)
+
 def parse_instructions(string):
     return parse_church_prime_string(string)
 

--- a/python/lib/ripl/console.py
+++ b/python/lib/ripl/console.py
@@ -76,15 +76,14 @@ class RiplCmd(Cmd, object):
 
   def _do_instruction(self, s, force_complete=False):
     if self.ripl.get_mode() == "church_prime":
-      # Not supporting multiline paste for abstract syntax yet
-      return self.ripl.execute_instructions(s)
+      from venture.parser.church_prime.parse import string_complete_p
     else:
       from venture.parser.venture_script.parse import string_complete_p
-      if force_complete or string_complete_p(s):
-        return self.ripl.execute_instructions(s)
-      else:
-        self.pending_instruction_string = s
-        self._update_prompt()
+    if force_complete or string_complete_p(s):
+      return self.ripl.execute_instructions(s)
+    else:
+      self.pending_instruction_string = s
+      self._update_prompt()
 
   @catchesVentureException
   def postcmd(self, stop, line):


### PR DESCRIPTION
It turns out that basically the same approach works as for the concrete syntax.
