### PR TITLE
Add any and all as builtin SPs

### DIFF
--- a/backend/lite/basic_sps.py
+++ b/backend/lite/basic_sps.py
@@ -79,6 +79,14 @@ registerBuiltinSP("xor", deterministic_typed(lambda x, y: x != y,
     [t.BoolType(), t.BoolType()], t.BoolType(),
     descr="xor(x,y) returns true if exactly one of x and y is true"))
 
+registerBuiltinSP("all", deterministic_typed(lambda arr: all(arr),
+    [t.HomogeneousListType(t.BoolType())], t.BoolType(),
+    descr="all returns true if all of the elements in the input are true"))
+
+registerBuiltinSP("any", deterministic_typed(lambda arr: any(arr),
+    [t.HomogeneousListType(t.BoolType())], t.BoolType(),
+    descr="any returns true if any of the elements in the input are true"))
+
 registerBuiltinSP("is_number", type_test(t.NumberType()))
 registerBuiltinSP("is_integer", type_test(t.IntegerType()))
 registerBuiltinSP("is_probability", type_test(t.ProbabilityType()))

--- a/test/conformance/sps/test_basics.py
+++ b/test/conformance/sps/test_basics.py
@@ -48,6 +48,19 @@ def testCompare():
   assert not get_ripl().predict("(>= 1 2)")
 
 @on_inf_prim("none")
+def testAnyAll():
+  # list argument
+  assert get_ripl().predict("(any (list True False True))")
+  assert not get_ripl().predict("(any (list False False False))")
+  assert get_ripl().predict("(all (list True True True))")
+  assert not get_ripl().predict("(all (list True False False))")
+  # array argument
+  assert get_ripl().predict("(any (array True False True))")
+  assert not get_ripl().predict("(any (array False False False))")
+  assert get_ripl().predict("(all (array True True True))")
+  assert not get_ripl().predict("(all (array True False False))")
+
+@on_inf_prim("none")
 def testRecordSmoke():
   assert not get_ripl().evaluate("(eq 1 (return 1))")
 


### PR DESCRIPTION
The procedures `any` and `all` are useful when writing predicates for checking conditions on the output of inference programs.

I did not implement Puma versions of these, only Lite versions.

As far as I can tell my implementations are not short-circuiting.

I tested this with:

```
(venturedp_env) Marcos-MacBook-Pro-2:Venturecxx marco$ nosetests -c crashes.cfg test/conformance/sps/test_basics.py:testAnyAll
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
test.conformance.sps.test_basics.testAnyAll ... ok

```
