### PR TITLE
Add each_reverse blocking

### DIFF
--- a/backend/lite/infer/dispatch.py
+++ b/backend/lite/infer/dispatch.py
@@ -95,6 +95,10 @@ def dispatch_arguments(trace, args):
       the_scope = trace.getScope(scope)
       blocks = the_scope.keys()
       return ([BlockScaffoldIndexer(scope, b) for b in blocks], transitions, extra)
+    elif block == "each_reverse":
+      the_scope = trace.getScope(scope)
+      blocks = the_scope.keys()[::-1]
+      return ([BlockScaffoldIndexer(scope, b) for b in blocks], transitions, extra)
     else:
       return ([BlockScaffoldIndexer(scope, block)], transitions, extra)
 

--- a/backend/lite/inference_sps.py
+++ b/backend/lite/inference_sps.py
@@ -191,7 +191,7 @@ don't actually read the state (e.g., for doing IO)"""
 
 inferenceSPsList = []
 
-inferenceKeywords = [ "default", "all", "none", "one", "each", "ordered" ]
+inferenceKeywords = [ "default", "all", "none", "one", "each", "each_reverse", "ordered" ]
 
 def registerBuiltinInferenceSP(name, sp_obj):
   inferenceSPsList.append([name, sp_obj])

--- a/backend/lite/trace.py
+++ b/backend/lite/trace.py
@@ -142,7 +142,7 @@ class Trace(object):
 
   def _normalizeEvaluatedScopeOrBlock(self, val):
     if isinstance(val, VentureSymbol):
-      if val.getSymbol() in ["default", "none", "one", "all", "each", "ordered"]:
+      if val.getSymbol() in ["default", "none", "one", "all", "each", "each_reverse", "ordered"]:
         return val.getSymbol()
     elif isinstance(val, VenturePair):
       if isinstance(val.first, VentureSymbol) and \

--- a/test/inference_language/test_basic_blocking.py
+++ b/test/inference_language/test_basic_blocking.py
@@ -121,6 +121,23 @@ def testBlockingExample4(seed):
     assert olda != newa
     assert oldb != newb
 
+@stochasticTest
+@broken_in("puma", "Puma does not support the 'each_reverse' block keyword (yet).")
+@on_inf_prim("mh")
+def testBlockingExample5(seed):
+  ripl = get_ripl(seed=seed)
+  ripl.assume("a", "(tag 0 0 (normal 0.0 1.0))", label="a")
+  ripl.assume("b", "(tag 0 1 (normal 1.0 1.0))", label="b")
+  for _ in range(10):
+    olda = ripl.report("a")
+    oldb = ripl.report("b")
+    # A deterministic sweep should touch each relevant block.
+    ripl.infer("(mh 0 each_reverse 1)")
+    newa = ripl.report("a")
+    newb = ripl.report("b")
+    assert olda != newa
+    assert oldb != newb
+
 @statisticalTest
 @broken_in('puma', "rejection is not implemented in Puma")
 @on_inf_prim("rejection")


### PR DESCRIPTION
Tested with:

```
nosetests -c inference-quality.cfg test/inference_language/test_basic_blocking.py:testBlockingExample5
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
nose.config: INFO: Excluding tests matching ['integration|performance|stack|unit|venturemagics|web_demos']
/home/sgeadmin/env/local/lib/python2.7/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.
  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')
test.inference_language.test_basic_blocking.testBlockingExample5 ... ok

===Flaky Test Report===


===End Flaky Test Report===
----------------------------------------------------------------------
Ran 1 test in 0.349s

OK
```
