### PR TITLE
Add missing modification of unicode string value

### DIFF
--- a/python/lib/sivm/core_sivm.py
+++ b/python/lib/sivm/core_sivm.py
@@ -249,7 +249,7 @@ def _modify_expression(expression):
     return expression
 
 def _modify_value(ob):
-    if ob['type'] == 'symbol':
+    if ob['type'] in ['symbol', 'string']:
         # Unicode hack for the same reason as in _modify_symbol
         ans = copy.copy(ob)
         ans['value'] = str(ob['value'])


### PR DESCRIPTION
Unicode strings passed in expressions to be evaluated were not modified, and resulted in the following exception when the puma backend was used:

```
*** evaluation: No registered converter was able to produce a C++ rvalue of type std::string from this Python object of type unicode
**************************************************
Stack trace from worker:
**************************************************
Traceback (most recent call last):
  File "/scratch/marcoct/ssifventure_test/env/local/lib/python2.7/site-packages/venture/multiprocess.py", line 104, in wrapped
    res = f(*args, **kwargs)
  File "/scratch/marcoct/ssifventure_test/env/local/lib/python2.7/site-packages/venture/multiprocess.py", line 342, in <lambda>
    return safely(lambda *args,**kwargs: getattr(self.obj, attrname)(*args, **kwargs))
  File "/scratch/marcoct/ssifventure_test/env/local/lib/python2.7/site-packages/venture/engine/trace.py", line 64, in evaluate
    self.trace.eval(baseAddr,exp)
TypeError: No registered converter was able to produce a C++ rvalue of type std::string from this Python object of type unicode

Caused by
No registered converter was able to produce a C++ rvalue of type std::string from this Python object of type unicode
**************************************************
Stack trace from worker:
**************************************************
Traceback (most recent call last):
  File "/scratch/marcoct/ssifventure_test/env/local/lib/python2.7/site-packages/venture/multiprocess.py", line 104, in wrapped
    res = f(*args, **kwargs)
  File "/scratch/marcoct/ssifventure_test/env/local/lib/python2.7/site-packages/venture/multiprocess.py", line 342, in <lambda>
    return safely(lambda *args,**kwargs: getattr(self.obj, attrname)(*args, **kwargs))
  File "/scratch/marcoct/ssifventure_test/env/local/lib/python2.7/site-packages/venture/engine/trace.py", line 64, in evaluate
    self.trace.eval(baseAddr,exp)
TypeError: No registered converter was able to produce a C++ rvalue of type std::string from this Python object of type unicode
```

The offending element of the expression was a unicode string.
