### PR TITLE
make pythenv.sh executable

### DIFF
--- a/pythenv.sh
+++ b/pythenv.sh
@@ -52,3 +52,4 @@ bindir="${root}/build/scripts-${version}"
 export PATH="${bindir}${PATH:+:${PATH}}"
 
 exec "$@"
+


### PR DESCRIPTION
pythenv.sh needs to be executable in order for 'make lint' in metaprob to work. After some searching (e.g. [here](https://blog.jdriven.com/2016/12/make-git-files-executable/)) I could not figure out how to do this without making a change to the file. So I added a blank line to the end. Feel free to employ a different method.
